### PR TITLE
Change output format style

### DIFF
--- a/lib/rails-i18n-debug/hook.rb
+++ b/lib/rails-i18n-debug/hook.rb
@@ -3,9 +3,10 @@ module I18n
     class Simple
       def lookup(locale, key, scope = [], options = {})
         init_translations unless initialized?
-        keys = I18n.normalize_keys(locale, key, scope, options[:separator])
 
-        i18n_logger.debug "I18N keys: #{keys}" if Rails.env.development?
+        keys = I18n.normalize_keys(locale, key, scope, options[:separator])
+        location = keys.map {|k| " #{k}:"}.join
+        i18n_logger.debug "I18N keys: #{location}" if Rails.env.development?
 
         keys.inject(translations) do |result, _key|
           _key = _key.to_sym


### PR DESCRIPTION
Change output format style:

`I18N keys:  cs: root: index: hello:
                    => Ahoj světe!`

instead of:

`I18N keys: ["cs", "root","index", "hello"]`

Can be better used in translation.
